### PR TITLE
Retrieve stats files over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Goal is to reproduce: https://www.nro.net/wp-content/uploads/apnic-uploads/deleg
 Input files are data from RIRs, and IANA files which is also from Jeff.
 
 ```
-    APNIC   -> "http://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest",
-    AFRINIC -> "http://ftp.afrinic.net/stats/afrinic/delegated-afrinic-extended-latest",
-    ARIN    -> "http://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest",
-    LACNIC  -> "http://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest",
+    APNIC   -> "https://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest",
+    AFRINIC -> "https://ftp.afrinic.net/stats/afrinic/delegated-afrinic-extended-latest",
+    ARIN    -> "https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest",
+    LACNIC  -> "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest",
     RIPENCC -> "https://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-extended-latest",
-    IANA    -> "http://ftp.apnic.net/pub/stats/iana/delegated-iana-latest",
+    IANA    -> "https://ftp.apnic.net/pub/stats/iana/delegated-iana-latest",
 ```
 
 ##

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -20,7 +20,7 @@ mkdir -p data/$THE_DAY
 
 cd data/$THE_DAY
 
-echo "Fetching http://ftp.apnic.net/stats/apnic/$YYYY/delegated-apnic-extended-$THE_DAY.gz"
+echo "Fetching https://ftp.apnic.net/stats/apnic/$YYYY/delegated-apnic-extended-$THE_DAY.gz"
 
 #Timeout 10 seconds
 CONNECT_TIMEOUT=10
@@ -29,14 +29,14 @@ RETRIES_COUNT=5
 # Exponential backoff
 RETRY_DELAY=0
 
-curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY http://ftp.apnic.net/stats/apnic/$YYYY/delegated-apnic-extended-$THE_DAY.gz --output apnic.gz
-curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY http://ftp.arin.net/pub/stats/arin/delegated-arin-extended-$DAY_BEFORE --output arin
-curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY http://ftp.afrinic.net/stats/afrinic/$YYYY/delegated-afrinic-extended-$THE_DAY --output afrinic
-curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY http://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-$DAY_BEFORE --output lacnic
+curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY https://ftp.apnic.net/stats/apnic/$YYYY/delegated-apnic-extended-$THE_DAY.gz --output apnic.gz
+curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-$DAY_BEFORE --output arin
+curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY https://ftp.afrinic.net/stats/afrinic/$YYYY/delegated-afrinic-extended-$THE_DAY --output afrinic
+curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-$DAY_BEFORE --output lacnic
 curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY https://ftp.ripe.net/pub/stats/ripencc/$YYYY/delegated-ripencc-extended-$DAY_BEFORE.bz2 --output ripencc.bz2
 
 # Special case for iana
-wget -4 ftp://ftp.apnic.net/pub/stats/iana/delegated-iana-latest -O iana
+curl --connect-timeout $CONNECT_TIMEOUT --retry $RETRIES_COUNT --retry-delay $RETRY_DELAY -4 https://ftp.apnic.net/stats/iana/delegated-iana-latest --output iana
 
 # Will override existing bz2
 bunzip2 -f ripencc.bz2

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -18,6 +18,7 @@ rscg.contact = "rsm-coord@nro.net"
 # How many days to look back for conflict
 grace.period = 2
 max.retries = 5
+# This is *NOT* a production account.
 mail {
     host = "smtp.mailtrap.io"
     port = 2525
@@ -30,12 +31,12 @@ mail {
 }
 
 urls {
-    apnic   = "http://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest"
-    afrinic = "http://ftp.afrinic.net/stats/afrinic/delegated-afrinic-extended-latest"
-    arin    = "http://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest"
-    lacnic  = "http://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest"
+    apnic   = "https://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest"
+    afrinic = "https://ftp.afrinic.net/stats/afrinic/delegated-afrinic-extended-latest"
+    arin    = "https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest"
+    lacnic  = "https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest"
     ripencc = "https://ftp.ripe.net/pub/stats/ripencc/delegated-ripencc-extended-latest"
-    iana    = "http://ftp.apnic.net/pub/stats/iana/delegated-iana-latest"
+    iana    = "https://ftp.apnic.net/pub/stats/iana/delegated-iana-latest"
 
     # Iana ORG sources
 
@@ -52,6 +53,4 @@ urls {
     ipv6-unicast-assignment = "https://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.csv"
     # Not currently used.
     ipv6-special-registry = "https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry-1.csv"
-
-
 }


### PR DESCRIPTION
  * replaced http urls with https
  * validated that **right now** the hashes on HTTP and HTTPS match

```
curl http://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest | shasum -a 256
curl https://ftp.apnic.net/stats/apnic/delegated-apnic-extended-latest | shasum -a 256

curl http://ftp.afrinic.net/stats/afrinic/delegated-afrinic-extended-latest | shasum -a 256
curl https://ftp.afrinic.net/stats/afrinic/delegated-afrinic-extended-latest | shasum -a 256

curl http://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest | shasum -a 256
curl https://ftp.arin.net/pub/stats/arin/delegated-arin-extended-latest | shasum -a 256

curl http://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest | shasum -a 256
curl https://ftp.lacnic.net/pub/stats/lacnic/delegated-lacnic-extended-latest | shasum -a 256
curl ftp://ftp.apnic.net/stats/iana/delegated-iana-latest | shasum -a 256
curl -L http://ftp.apnic.net/pub/stats/iana/delegated-iana-latest | shasum -a 256
curl -L https://ftp.apnic.net/pub/stats/iana/delegated-iana-latest | shasum -a 256
```