### PR TITLE
Separate notifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ compare/**
 .DS_Store
 log
 project/metals.sbt
+.bsp

--- a/README.md
+++ b/README.md
@@ -25,14 +25,34 @@ We are not performing EU country code mapping that was done in the original NRO 
  
 Building single jar assembly can be done with `sbt assembly` and look for `nro-delegated-stats.jar` in target directory.
 
-Once the jar is build, there is optional JVM parameter that you can give, startDate and endDate e.g:
+There are two main operations that can be performed. Generating the delegated extended stats, and notification/email
+to existing Registry contacts of RIRs in case of persisting conflicts.
+
+Here are the description of available command lines.
 
 ```
-java -DstartDate=2019-11-01 -DendDate=2019-11-10 -jar nro-delegated-stats.jar
+NRO Extended Allocation and Assignments Statistics
+Usage: NRO Delegated Extended Statistics [generate|notify]
 
+Command: generate [options]
+Generate NRO Delegated Extended Statistic, based on each RIRs delegated stats and IANA file
+  -s, --startDate <value>  Start date for processing NRO delegated stat, default to today: YYYY-MM-DD
+  -e, --endDate <value>    End date for processing NRO delegated stat, default to today: YYYY-MM-DD
+  --ownIana                Use own generated IANA file as input
+Command: notify [options]
+Notify RS contacts if there are persistent conflicts over a grace period
+  -b, --base-url <value>   Base url for retrieving conflicts, defaults to: https://ftp.ripe.net/pub/stats/ripencc/nro-stats/.
+  -c, --conflict-date <value>
+                           Current conflict date, defaults to today: YYYY-MM-DD
 ```
 
-Not giving these parameters will run the program only for today. Giving only start day will run it up to today.
+For `generate` operation, by default the script will generate stats for today. 
+You can configure to run it for past days by setting appropriate start/end date parameters.
+
+For `notify` operation you need to provide `base-url` to fetch previous conflicts, with defaults to ftp.ripe.net.
+
+Other application configuration that are not supplied via command line are provided in this [application.conf](https://github.com/RIPE-NCC/nro-delegated-stats/blob/main/src/main/resources/application.conf)
+which by default is bundled, but can be overriden.
 
 ##
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Command: generate [options]
 Generate NRO Delegated Extended Statistic, based on each RIRs delegated stats and IANA file
   -s, --startDate <value>  Start date for processing NRO delegated stat, default to today: YYYY-MM-DD
   -e, --endDate <value>    End date for processing NRO delegated stat, default to today: YYYY-MM-DD
-  --ownIana                Use own generated IANA file as input
+  --ownIana                Use own generated IANA file as input, defaults to using http://ftp.apnic.net/stats/iana/delegated-iana-latest
 Command: notify [options]
 Notify RS contacts if there are persistent conflicts over a grace period
   -b, --base-url <value>   Base url for retrieving conflicts, defaults to: https://ftp.ripe.net/pub/stats/ripencc/nro-stats/.

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Building single jar assembly can be done with `sbt assembly` and look for `nro-d
 There are two main operations that can be performed. Generating the delegated extended stats, and notification/email
 to existing Registry contacts of RIRs in case of persisting conflicts.
 
-Here are the description of available command lines.
+Here are the description of available command lines options.
 
 ```
 NRO Extended Allocation and Assignments Statistics
-Usage: NRO Delegated Extended Statistics [generate|notify]
+Usage: java -jar nro-delegated-stats.jar [generate|notify]
 
 Command: generate [options]
 Generate NRO Delegated Extended Statistic, based on each RIRs delegated stats and IANA file
@@ -52,7 +52,7 @@ You can configure to run it for past days by setting appropriate start/end date 
 For `notify` operation you need to provide `base-url` to fetch previous conflicts, with defaults to ftp.ripe.net.
 
 Other application configuration that are not supplied via command line are provided in this [application.conf](https://github.com/RIPE-NCC/nro-delegated-stats/blob/main/src/main/resources/application.conf)
-which by default is bundled, but can be overriden.
+which by default is bundled, but can be overriden using `-Dconfig.file=<application.conf>`.
 
 ##
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,5 +6,5 @@ name := "nro-delegated-stats"
 
 scalaVersion := "2.13.6"
 libraryDependencies ++= mainDeps ++ logConfDeps ++ testDeps
-mainClass in assembly := Some("net.ripe.rpki.nro.Main")
-assemblyJarName in assembly := "nro-delegated-stats.jar"
+assembly / mainClass := Some("net.ripe.rpki.nro.Main")
+assembly / assemblyJarName := "nro-delegated-stats.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "0.1"
 organization := "net.ripe.nro.stat"
 name := "nro-delegated-stats"
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.6"
 libraryDependencies ++= mainDeps ++ logConfDeps ++ testDeps
 mainClass in assembly := Some("net.ripe.rpki.nro.Main")
 assemblyJarName in assembly := "nro-delegated-stats.jar"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   val guava = "com.google.guava" % "guava" % "28.1-jre"
   val requests = "com.lihaoyi" %% "requests" % "0.2.0"
 
+  val scopt = "com.github.scopt" %% "scopt" % "4.0.1"
   val csvReader = "com.github.tototoshi" %% "scala-csv" % "1.3.6"
   val mailCourier = "com.github.daddykotex" %% "courier" % "3.0.1"
   val retry = "com.softwaremill.retry" %% "retry" % "0.3.3"
@@ -16,8 +17,7 @@ object Dependencies {
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % Test
   val mockMail = "com.icegreen" % "greenmail" % "1.6.5" % Test
 
-
-  val mainDeps: Seq[ModuleID] = Seq(commonsIpMath, guava, requests, csvReader, mailCourier, retry)
+  val mainDeps: Seq[ModuleID] = Seq(scopt, commonsIpMath, guava, requests, csvReader, mailCourier, retry)
   val logConfDeps: Seq[ModuleID] = Seq(typesafeConfig, logbackClassic)
   val testDeps: Seq[ModuleID] = Seq(scalatest, mockMail)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,14 +7,15 @@ object Dependencies {
   val requests = "com.lihaoyi" %% "requests" % "0.2.0"
 
   val csvReader = "com.github.tototoshi" %% "scala-csv" % "1.3.6"
-  val mailCourier = "com.github.daddykotex" %% "courier" % "2.0.0"
+  val mailCourier = "com.github.daddykotex" %% "courier" % "3.0.1"
   val retry = "com.softwaremill.retry" %% "retry" % "0.3.3"
 
   val typesafeConfig = "com.typesafe" % "config" % "1.3.4"
   val logbackClassic = "ch.qos.logback" % "logback-classic" % "1.2.3"
 
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % Test
-  val mockMail = "org.jvnet.mock-javamail" % "mock-javamail" % "1.9" % Test
+  val mockMail = "com.icegreen" % "greenmail" % "1.6.5" % Test
+
 
   val mainDeps: Seq[ModuleID] = Seq(commonsIpMath, guava, requests, csvReader, mailCourier, retry)
   val logConfDeps: Seq[ModuleID] = Seq(typesafeConfig, logbackClassic)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.6
+sbt.version = 1.5.5

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,35 @@
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %level [%thread] %logger{0} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>nro-stats.log</file>
+        <encoder>
+            <pattern>%date %level [%thread] %logger{0} %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>nro-stats.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>60</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="ERRORFILE" class="ch.qos.logback.core.FileAppender">
+        <file>nro-stats.err</file>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+       <encoder>
+            <pattern>%date %level [%thread] %logger{0} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="CONSOLE" />
+<!--        <appender-ref ref="FILE" />-->
+<!--        <appender-ref ref="ERRORFILE" />-->
+    </root>
+</configuration>

--- a/src/main/scala/net/ripe/rpki/nro/Configs.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Configs.scala
@@ -8,7 +8,7 @@ import courier.Mailer
 import net.ripe.rpki.nro.Const._
 import org.slf4j.LoggerFactory
 
-class Configs(todayDate: LocalDate) {
+class Configs(private val todayDate: LocalDate) {
   import Configs._
 
   def CURRENT_DAY: String = formatDate(todayDate)
@@ -39,6 +39,9 @@ class Configs(todayDate: LocalDate) {
 }
 
 object Configs {
+  def configureFor(todayDate: LocalDate) = {
+    config = new Configs(todayDate)
+  }
   private val conf: Config = ConfigFactory.load()
   val urls: Config = conf.getConfig("urls")
   val sender : String = conf.getString("sender")
@@ -52,7 +55,7 @@ object Configs {
   )
 
   // Left is a path to external file, right is a source from classpath resource will be treated differently
-  val allowedList: Either[String, String] = if(conf.hasPath("allowedlist")) Left(conf.getString("allowedlist")) else Right("allowedlist") 
+  val allowedList: Either[String, String] = if(conf.hasPath("allowedlist")) Left(conf.getString("allowedlist")) else Right("allowedlist")
   val gracePeriod: Int = conf.getInt("grace.period")
   val maxRetries: Int = conf.getInt("max.retries")
   val dataDirectory: String = conf.getString("data.directory")

--- a/src/main/scala/net/ripe/rpki/nro/Configs.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Configs.scala
@@ -105,5 +105,5 @@ object Configs {
 }
 
 trait Logging {
-  val logger = LoggerFactory.getLogger(getClass.getName)
+  def logger = LoggerFactory.getLogger(getClass.getName)
 }

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -58,18 +58,18 @@ object Main extends Stats with App {
         .text("Use own generated IANA file as input"),
       opt[Environments]("environment")
         .action((env, cli) ⇒ cli.copy(environment = env))
-        .text("Environment: local/production"),
+        .text("Optional environment where the script runs. \nAvailable option values: local | prepdev | production"),
      opt[Operations]("operation")
         .required()
         .action((operationArgs, cli) ⇒ cli.copy(operation = operationArgs))
-        .text("Operations to perform, generate or notify"),
+        .text("Operations to perform whether to generate the NRO Delegated Stats, or to perform notification/email. \nAvailable option values : generate | notify"),
     )
   }
 
   var CommandLineOptions(startDate, endDate, ownIana, environment, operation) =
     OParser.parse(argsParser, args, CommandLineOptions()) match {
       case Some(commandLineOptions) => commandLineOptions
-      case _ => System.exit(1)
+      case _ => System.exit(1) // some options parse error, usage message from scopt will be shown
     }
 
   configureLogging()
@@ -113,8 +113,17 @@ object Main extends Stats with App {
     Configs.config = new Configs(startDate)
 
     val (allowedList, previousConflicts, currentConflicts): (Records, List[Conflict], List[Conflict]) = Ports.getConflicts()
+    logger.info("Allowed list:")
+    allowedList.all.foreach(item ⇒ logger.info(item.toString))
+
+    logger.info("Current conflict:")
+    currentConflicts.foreach(item ⇒ logger.info(item.toString))
+
+    logger.info("Previous conflict:")
+    currentConflicts.foreach(item ⇒ logger.info(item.toString))
+
     val notifier = new Notifier(mailer, allowedList.all)
-    notifier.notifyConflicts(currentConflicts, previousConflicts)
+    logger.info(notifier.notifyConflicts(currentConflicts, previousConflicts))
   }
 
   def configureLogging(){

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -45,7 +45,7 @@ object Main extends Stats with App {
             .text("End date for processing NRO delegated stat, default to today: YYYY-MM-DD"),
           opt[Unit]("ownIana")
             .action((_, cli) => cli.copy(ownIana = true))
-            .text("Use own generated IANA file as input"),
+            .text("Use own generated IANA file as input, defaults to using http://ftp.apnic.net/stats/iana/delegated-iana-latest"),
         ),
       cmd("notify")
         .text("Notify RS contacts if there are persistent conflicts over a grace period")

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -90,8 +90,8 @@ object Main extends Stats with App {
     while (startDate.compareTo(endDate) <= 0) {
 
       Configs.configureFor(startDate)
-      logger.info("Data dir: " + Configs.config.currentDataDirectory)
-      logger.info("Result dir: " + Configs.config.currentResultDirectory)
+      logger.info(s"Data dir: $Configs.config.currentDataDirectory")
+      logger.info(s"Result dir: $Configs.config.currentResultDirectory")
 
       val (rirRecords, ianaRecord, previousResult) = Ports.fetchAndParseInputs(ownIana)
       val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(rirRecords, ianaRecord, previousResult)

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -33,8 +33,8 @@ case class CommandLineOptions(
 
 object CommandLineOptions {
   implicit val localDateRead: scopt.Read[LocalDate] = scopt.Read.reads(LocalDate.parse)
-  implicit val operationsReads: scopt.Read[Operations.Value] = scopt.Read.reads(Operations withName _)
-  implicit val environmentReads: scopt.Read[Environments.Value] = scopt.Read.reads(Environments withName _)
+  implicit val operationsReads: scopt.Read[Operations.Value] = scopt.Read.reads(Operations withName _.capitalize)
+  implicit val environmentReads: scopt.Read[Environments.Value] = scopt.Read.reads(Environments withName _.capitalize)
 }
 
 object Main extends Stats with App {
@@ -53,23 +53,24 @@ object Main extends Stats with App {
       opt[LocalDate]('e',"endDate")
         .action((endDateArgs, cli) => cli.copy(endDate=endDateArgs))
         .text("End date for processing nro delegated stat: YYYY-MM-DD"),
-      opt[Boolean]('i', "ownIana")
-        .action((ownIana, cli) ⇒ cli.copy(ownIana = ownIana))
+      opt[Unit]("ownIana")
+        .action((_, cli) ⇒ cli.copy(ownIana = true))
         .text("Use own generated IANA file as input"),
       opt[Environments]("environment")
         .action((env, cli) ⇒ cli.copy(environment = env))
         .text("Environment: local/production"),
      opt[Operations]("operation")
         .required()
-        .action((operation, cli) ⇒ cli.copy(operation = operation))
+        .action((operationArgs, cli) ⇒ cli.copy(operation = operationArgs))
         .text("Operations to perform, generate or notify"),
     )
   }
 
-  var CommandLineOptions(startDate, endDate, ownIana, environment, operation ) = OParser.parse(argsParser, args, CommandLineOptions()) match {
-    case Some(commandLineOptions) => commandLineOptions
-    case _ => System.exit(1)
-  }
+  var CommandLineOptions(startDate, endDate, ownIana, environment, operation) =
+    OParser.parse(argsParser, args, CommandLineOptions()) match {
+      case Some(commandLineOptions) => commandLineOptions
+      case _ => System.exit(1)
+    }
 
   configureLogging()
 

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -31,8 +31,8 @@ object Main extends Stats with App {
     import net.ripe.rpki.nro.CommandLineOptions._
     import net.ripe.rpki.nro.Main.builder._
     OParser.sequence(
-      programName("NRO Delegated Extended Statistics"),
       head("NRO Extended Allocation and Assignments Statistics"),
+      programName("java -jar nro-delegated-stats.jar"),
       cmd("generate")
         .text("Generate NRO Delegated Extended Statistic, based on each RIRs delegated stats and IANA file")
         .action((_, cli) => cli.copy(operation = "generate"))

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -1,7 +1,8 @@
 package net.ripe.rpki.nro
 
-import java.time.LocalDate
+import ch.qos.logback.classic.LoggerContext
 
+import java.time.LocalDate
 import net.ripe.rpki.nro.Configs._
 import net.ripe.rpki.nro.main.Stats
 import net.ripe.rpki.nro.service.{Notifier, Ports}
@@ -9,47 +10,66 @@ import net.ripe.rpki.nro.service.{Notifier, Ports}
 import scala.util.{Properties, Try}
 import ch.qos.logback.classic.joran.JoranConfigurator
 import ch.qos.logback.core.joran.spi.JoranException
+import net.ripe.rpki.nro.model.{Conflict, Records}
 
 object Main extends Stats with App {
 
   var startDate   = Properties.propOrNone("startDate").map(LocalDate.parse).getOrElse(LocalDate.now)
   val endDate     = Properties.propOrNone("endDate").map(LocalDate.parse).getOrElse(LocalDate.now)
+
   val ownMagic    = Properties.propOrNone("ownMagic").isDefined
   val environment = Properties.propOrElse("environment", "local")
+  val operation   = Properties.propOrElse("operation", "generate")
 
   configureLogging()
 
-  if (startDate.equals(endDate)) {
-    logger.info("Generating stats for a single day ", startDate)
-  } else {
-    logger.info(s"Generating stats from $startDate to $endDate")
+  if("generate" == operation)
+    generateDelegatedStats()
+
+  if("notify" == operation)
+    checkConflictsAndNotify()
+
+  def generateDelegatedStats(): Unit = {
+
+    if (startDate.equals(endDate)) {
+      logger.info("Generating stats for a single day ", startDate)
+    } else {
+      logger.info(s"Generating stats from $startDate to $endDate")
+    }
+
+    while (startDate.compareTo(endDate) <= 0) {
+
+      Configs.config = new Configs(startDate)
+      logger.info("Data dir: " + Configs.config.currentDataDirectory)
+      logger.info("Result dir: " + Configs.config.currentResultDirectory)
+
+      val (rirRecords, ianaRecord, previousResult) = Ports.fetchAndParseInputs(ownMagic)
+      val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(rirRecords, ianaRecord, previousResult)
+
+
+      Ports.writeRecords(results, config.currentResultFile)
+      Ports.writeRecords(mergedResults, config.currentMergedFile)
+      Ports.writeConflicts(currentConflicts, config.currentConflictFile)
+
+      Ports.writeClaims(unclaimed, config.currentUnclaimedFile)
+      Ports.writeClaims(overclaimed, config.currentOverclaimedFile)
+
+      startDate = startDate.plusDays(1)
+    }
   }
 
-  while (startDate.compareTo(endDate) <= 0) {
+  def checkConflictsAndNotify() : Unit = {
 
     Configs.config = new Configs(startDate)
-    logger.info("Data dir: " + Configs.config.currentDataDirectory)
-    logger.info("Result dir: " + Configs.config.currentResultDirectory)
 
-    val (rirRecords, ianaRecord, previousResult, previousConflicts, allowedList) = Ports.fetchAndParse(ownMagic)
-    val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(rirRecords, ianaRecord, previousResult, previousConflicts)
-
+    val (allowedList, previousConflicts, currentConflicts): (Records, List[Conflict], List[Conflict]) = Ports.getConflicts()
     val notifier = new Notifier(mailer, allowedList.all)
     notifier.notifyConflicts(currentConflicts, previousConflicts)
-
-    Ports.writeRecords(results, config.currentResultFile)
-    Ports.writeRecords(mergedResults, config.currentMergedFile)
-    Ports.writeConflicts(currentConflicts, config.currentConflictFile)
-
-    Ports.writeClaims(unclaimed, config.currentUnclaimedFile)
-    Ports.writeClaims(overclaimed, config.currentOverclaimedFile)
-
-    startDate = startDate.plusDays(1)
   }
 
   def configureLogging(){
     val configurator = new JoranConfigurator
-    val context = org.slf4j.LoggerFactory.getILoggerFactory.asInstanceOf[ch.qos.logback.classic.LoggerContext]
+    val context = org.slf4j.LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
     try{
       configurator.setContext(context)
       context.reset()

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -71,8 +71,6 @@ object Main extends Stats with App {
       case _ => System.exit(1) // some options parse error, usage message from scopt will be shown
     }
 
-  configureLogging()
-
   operation match {
     case "generate" ⇒ generateDelegatedStats()
     case "notify"   ⇒ checkConflictsAndNotify(baseConflictsURL)
@@ -121,20 +119,9 @@ object Main extends Stats with App {
     logger.info("Previous conflict:")
     currentConflicts.foreach(item ⇒ logger.info(item.toString))
 
-    logger.info(username + " "+password+ " " + host)
     val notifier = new Notifier(mailer, allowedList.all)
     val stickyConflicts = notifier.findStickyConflicts(currentConflicts, previousConflicts)
     notifier.notifyConflicts(stickyConflicts)
   }
 
-  def configureLogging(){
-    val configurator = new JoranConfigurator
-    val context = org.slf4j.LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
-    try{
-      configurator.setContext(context)
-      context.reset()
-    }catch {
-      case e: JoranException =>
-    }
-  }
 }

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -7,7 +7,9 @@ import net.ripe.rpki.nro.service.{Notifier, Ports}
 import org.slf4j.LoggerFactory
 import scopt.OParser
 
+import java.net.URL
 import java.time.LocalDate
+import scala.util.{Failure, Success, Try}
 
 case class CommandLineOptions(
                                operation: String = "",
@@ -58,7 +60,11 @@ object Main extends Stats with App {
             .text("Current conflict date, defaults to today: YYYY-MM-DD")
             .action((conflictDateArgs, cli) => cli.copy(conflictDate = conflictDateArgs))
         ),
-      checkConfig(cli => if (cli.operation.isEmpty) failure("You need to specify operations [generate | notify] ") else success)
+      checkConfig(cli => if (cli.operation.isEmpty) failure("You need to specify operations [generate | notify] ") else success),
+      checkConfig(cli => Try(new URL(cli.base).getHost) match {
+        case Success(_)  => success
+        case Failure(e) => failure(s"Base URL can't be parsed ${e.getMessage}")
+      })
     )
   }
 

--- a/src/main/scala/net/ripe/rpki/nro/Main.scala
+++ b/src/main/scala/net/ripe/rpki/nro/Main.scala
@@ -82,7 +82,7 @@ object Main extends Stats with App {
   def generateDelegatedStats(): Unit = {
 
     if (startDate.equals(endDate)) {
-      logger.info("Generating stats for a single day ", startDate)
+      logger.info(s"Generating stats for a single day $startDate")
     } else {
       logger.info(s"Generating stats from $startDate to $endDate")
     }

--- a/src/main/scala/net/ripe/rpki/nro/main/Merger.scala
+++ b/src/main/scala/net/ripe/rpki/nro/main/Merger.scala
@@ -161,7 +161,7 @@ trait Merger extends Logging with Ranges {
       val previousMap: RangeMap[BigInteger, Record] = asRangeMap(prevRecords)
       val currentMap = TreeRangeMap.create[BigInteger, Record]()
 
-      currRecords.map { record ⇒
+      currRecords.map { record =>
         val range: Range[BigInteger] = record.range.key
         val previousOverlaps = previousMap.subRangeMap(range)
 

--- a/src/main/scala/net/ripe/rpki/nro/main/Stats.scala
+++ b/src/main/scala/net/ripe/rpki/nro/main/Stats.scala
@@ -9,8 +9,7 @@ trait Stats extends Logging with Merger {
   // Main steps of stats merging and conflict detections.
   def process(rirRecords: Iterable[Records],
               ianaRecord: Records,
-              previousResult: Option[Records],
-              previousConflicts: List[Conflict]): (Records, Records, List[Conflict], Records, Records) = {
+              previousResult: Option[Records]): (Records, Records, List[Conflict], Records, Records) = {
 
     logger.info(s"\n\n---  Combining RIRs data and checking for conflicts among RIRs ---\n\n")
 

--- a/src/main/scala/net/ripe/rpki/nro/service/Notifier.scala
+++ b/src/main/scala/net/ripe/rpki/nro/service/Notifier.scala
@@ -13,7 +13,7 @@ import net.ripe.rpki.nro.model.Record
 
 class Notifier(mailer: Mailer, allowedList : List[Record]) extends Logging {
 
-  def isAllowed(c : Conflict) = {
+  def isAllowed(c : Conflict): Boolean = {
       val check = allowedList.contains(c.a) || allowedList.contains(c.b) 
       if(check)
         logger.info(s"$c is allowed")
@@ -48,7 +48,7 @@ class Notifier(mailer: Mailer, allowedList : List[Record]) extends Logging {
   }
 
   def sendConflicts(conflicts: Set[Conflict]): Unit ={
-    var rsContacts: Array[String] = conflicts.flatMap(c => Set(c.a.registry, c.b.registry)).filter(_ != Const.IANA).map(contacts).toArray :+ contacts(RSCG)
+    val rsContacts: Array[String] = conflicts.flatMap(c => Set(c.a.registry, c.b.registry)).filter(_ != Const.IANA).map(contacts).toArray :+ contacts(RSCG)
     val envelope: Envelope = Envelope
       .from(sender.addr)
       .to(rsContacts.map(_.addr):_*)

--- a/src/main/scala/net/ripe/rpki/nro/service/Ports.scala
+++ b/src/main/scala/net/ripe/rpki/nro/service/Ports.scala
@@ -147,12 +147,7 @@ object Ports extends Logging {
     }
   }
 
-  def fetchAndParse(ownmagic: Boolean = true): (Iterable[Records], Records, Option[Records], List[Conflict], Records) = {
-
-    val allowedListRecords = allowedList match {
-      case Left(path) => parseRecordFile(path)
-      case Right(resource) => parseRecordSource(resource)
-    }
+  def fetchAndParseInputs(ownmagic: Boolean = true): (Iterable[Records], Records, Option[Records]) = {
 
     val recordMaps: Map[String, Records] = sources.map {
       case (name:String, url:String) =>
@@ -171,8 +166,21 @@ object Ports extends Logging {
     }
 
     val previousResult = Try(parseRecordFile(s"${config.previousResultFile}")).toOption
-    val oldConflict = Try(readConflicts(s"${config.previousConflictFile}")).getOrElse(List())
-    (rirs, iana, previousResult, oldConflict, allowedListRecords)
+
+    (rirs, iana, previousResult)
+  }
+
+  def getConflicts(): (Records,  List[Conflict], List[Conflict]) = {
+
+    val allowedListRecords = allowedList match {
+      case Left(path) => parseRecordFile(path)
+      case Right(resource) => parseRecordSource(resource)
+    }
+
+    val currentConflicts  = Try(readConflicts(s"${config.currentConflictFile}")).getOrElse(List())
+    val previousConflicts = Try(readConflicts(s"${config.previousConflictFile}")).getOrElse(List())
+
+    (allowedListRecords, previousConflicts, currentConflicts)
   }
 
   def writeRecords(records: Records, outputFile: String = s"$resultFileName", header: Boolean = true): Unit = {

--- a/src/test/scala/net/ripe/rpki/nro/TestUtil.scala
+++ b/src/test/scala/net/ripe/rpki/nro/TestUtil.scala
@@ -1,8 +1,7 @@
 package net.ripe.rpki.nro
 
-import java.io.StringReader
+import java.io.{FileReader, Reader, StringReader}
 import java.util.Properties
-
 import com.github.tototoshi.csv.CSVReader
 import courier.Mailer
 import net.ripe.rpki.nro.model.Record
@@ -16,5 +15,6 @@ trait TestUtil {
 
   def getResourceFile(fileName: String): String = getClass.getResource(fileName).getFile
 
+  def getResourceReader(fileName:String): Reader = new FileReader(getResourceFile(fileName))
 
 }

--- a/src/test/scala/net/ripe/rpki/nro/TestUtil.scala
+++ b/src/test/scala/net/ripe/rpki/nro/TestUtil.scala
@@ -6,23 +6,15 @@ import java.util.Properties
 import com.github.tototoshi.csv.CSVReader
 import courier.Mailer
 import net.ripe.rpki.nro.model.Record
-import net.ripe.rpki.nro.service.MockedSMTPProvider
 import net.ripe.rpki.nro.service.Ports.PipeFormat
 
 trait TestUtil {
+
 
   def toRecords(testInputs: String): List[Record] =
     CSVReader.open(new StringReader(testInputs)).all.map(Record.apply)
 
   def getResourceFile(fileName: String): String = getClass.getResource(fileName).getFile
 
-  lazy val mockMailer: Mailer = {
-    val mockedProperty = new Properties()
-    mockedProperty.put("mail.transport.protocol.rfc822", "mocked")
 
-    val mockedSession = javax.mail.Session.getDefaultInstance(mockedProperty)
-    mockedSession.setProvider(new MockedSMTPProvider)
-
-    Mailer(mockedSession)
-  }
 }

--- a/src/test/scala/net/ripe/rpki/nro/main/StatsTest.scala
+++ b/src/test/scala/net/ripe/rpki/nro/main/StatsTest.scala
@@ -13,7 +13,7 @@ class StatsTest extends FlatSpec with Stats with TestUtil with Logging {
     val arin = parseRecordFile(getResourceFile("/data/arin")).formatRIRs
     val afriaprin = parseRecordFile(getResourceFile("/data/afriaprin")).formatRIRs
 
-    val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(Iterable(apnic, afrinic, arin, afriaprin), iana, None, List())
+    val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(Iterable(apnic, afrinic, arin, afriaprin), iana, None)
 
     assert(mergedResults.size <= results.size)
     assert(currentConflicts.size === 300)
@@ -29,7 +29,7 @@ class StatsTest extends FlatSpec with Stats with TestUtil with Logging {
     val arin = parseRecordFile(getResourceFile("/data/arin")).formatRIRs
     val previous = parseRecordFile(getResourceFile("/data/previous")).formatRIRs
 
-    val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(Iterable(apnic, afrinic, arin), iana, Some(previous), List())
+    val (results, mergedResults, currentConflicts, unclaimed, overclaimed) = process(Iterable(apnic, afrinic, arin), iana, Some(previous))
 
     assert(mergedResults.size <= results.size)
     assert(currentConflicts.isEmpty)

--- a/src/test/scala/net/ripe/rpki/nro/model/RecordsFormatTest.scala
+++ b/src/test/scala/net/ripe/rpki/nro/model/RecordsFormatTest.scala
@@ -12,7 +12,7 @@ class RecordsFormatTest extends FlatSpec with TestUtil {
     val iana  = parseRecordFile(getResourceFile("/data/iana"))
     val stats = iana.asn.map(_.stat) ++ iana.ipv4.map(_.stat) ++ iana.ipv6.map(_.stat)
 
-    stats.foreach( stat ⇒
+    stats.foreach( stat =>
         assert(
           (stat.status == RESERVED && stat.oid == IETF) ||
           (stat.status == ASSIGNED && stat.oid == IANA) ||
@@ -23,7 +23,7 @@ class RecordsFormatTest extends FlatSpec with TestUtil {
     val unclaimed = parseRecordFile(getResourceFile("/data/iana")).formatUnclaimed
     val stats = unclaimed.asn.map(_.stat) ++ unclaimed.ipv4.map(_.stat) ++ unclaimed.ipv6.map( _.stat)
 
-    stats.foreach( stat ⇒
+    stats.foreach( stat =>
         assert(
           stat.date == config.CURRENT_DAY &&
           stat.status == AVAILABLE
@@ -34,7 +34,7 @@ class RecordsFormatTest extends FlatSpec with TestUtil {
     val ripe  = parseRecordFile(getResourceFile("/data/arin")).formatRIRs
     val stats = ripe.asn.map(_.stat) ++ ripe.ipv4.map(_.stat) ++ ripe.ipv6.map( _.stat)
 
-    stats.foreach { stat ⇒
+    stats.foreach { stat =>
       if (stat.status == RESERVED || stat.status == AVAILABLE) {
         assert(stat.date == config.CURRENT_DAY && stat.cc == DEFAULT_CC && stat.oid == stat.registry)
       }

--- a/src/test/scala/net/ripe/rpki/nro/service/NotifierTest.scala
+++ b/src/test/scala/net/ripe/rpki/nro/service/NotifierTest.scala
@@ -42,7 +42,7 @@ class NotifierTest extends FlatSpec with TestUtil {
     assert(messages.map(_.getSubject).toSet == Set(s"There are conflicting delegated stats since ${config.PREV_CONFLICT_DAY}"))
 
     allowedList.foreach{allowedListed =>
-      messages.foreach(mimeMessage ⇒
+      messages.foreach(mimeMessage =>
         assert(!mimeMessage.getContent().toString.contains(allowedListed))
       )
     }

--- a/src/test/scala/net/ripe/rpki/nro/service/PortsTest.scala
+++ b/src/test/scala/net/ripe/rpki/nro/service/PortsTest.scala
@@ -23,37 +23,15 @@ class PortsTest extends FlatSpec with TestUtil {
     assert(iana.ipv6.size == 6)
   }
 
-  it should "deserialize conflict in proper location " in {
-
-    val ripe =
-      """|ripencc|AU|ipv4|1.10.10.0|256|20110811|assigned|A9173591
-         |ripencc|CN|ipv4|1.10.16.0|4096|20110412|allocated|A92319D5""".stripMargin
-
-    val apnic =
-      """|apnic|AU|ipv4|1.10.10.0|256|20110811|assigned|A9173591
-         |apnic|CN|ipv4|1.10.11.0|256|20110414|allocated|A92E1062""".stripMargin
-
-    val ripeRecs = toRecords(ripe)
-    val apnicRecs = toRecords(apnic)
-
-    val original = ripeRecs.zip(apnicRecs).map { case (a, b) => Conflict(a, b) }
-    val tempOutput = File.createTempFile("conflict","txt")
-
-    writeConflicts(original, tempOutput.toString)
-    val readBack = readConflicts(tempOutput.toString)
-
-    assert(readBack == original)
-
+  it should "deserialize conflict " in {
+    val fetchConflicts = readConflicts("https://ftp.ripe.net/pub/stats/ripencc/nro-stats/20210810/conflicts")
+    assert(fetchConflicts.size == 7)
   }
 
   it should "deserialize empty conflicts" in {
     val noConflict = List[Conflict]()
-    val tempOutput = File.createTempFile("conflict","txt")
-    writeConflicts(noConflict, tempOutput.toString)
-    val readBack = readConflicts(tempOutput.toString)
-    assert(readBack == noConflict)
-
+    val fetched = readConflicts("https://ftp.ripe.net/pub/stats/ripencc/nro-stats/20210810/unclaimed")
+    assert(fetched == noConflict)
   }
-
 
 }


### PR DESCRIPTION
Now scripts can do two operations depending on command line parameters, generate stats, or notify based on previous/current conflicts.

Actual scripts/pipeline calling this needs to be adjusted according to following new command line options:

```
NRO Extended Allocation and Assignments Statistics
Usage: NRO Delegated Extended Statistics [generate|notify]

Command: generate [options]
Generate NRO Delegated Extended Statistic, based on each RIRs delegated stats and IANA file
  -s, --startDate <value>  Start date for processing NRO delegated stat, default to today: YYYY-MM-DD
  -e, --endDate <value>    End date for processing NRO delegated stat, default to today: YYYY-MM-DD
  --ownIana                Use own generated IANA file as input
Command: notify [options]
Notify RS contacts if there are persistent conflicts over a grace period
  -b, --base-url <value>   Base url for retrieving conflicts, defaults to: https://ftp.ripe.net/pub/stats/ripencc/nro-stats/.
  -c, --conflict-date <value>
                           Current conflict date, defaults to today: YYYY-MM-DD
```                           