### PR TITLE
github: replace sbt container with setup-scala

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,15 @@ jobs:
   sbt-build-test:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
-    # Docker Hub image that `container-job` executes in
-    container: mozilla/sbt
 
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - uses: olafurpg/setup-scala@v13
+        with:
+          java-version: openjdk@1.17
 
       - name: Compile
         run: sbt compile
@@ -27,13 +29,13 @@ jobs:
         run: mv $(find target -name nro-delegated-stats.jar) artifacts/
 
       - name: Upload jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: artifacts
           path: artifacts
 
       - name: Upload reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: reports
           path: |
@@ -47,10 +49,10 @@ jobs:
 
     steps:
       - name: checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: artifacts
 
@@ -58,14 +60,14 @@ jobs:
         run: ls -ltR
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push
         id: docker_build_nro_delegated_stats


### PR DESCRIPTION
The mozilla/sbt container no longer works Github Actions. Replace it with the
more commonly used olafurpg/setup-scala action.

Also update the used github actions.